### PR TITLE
radiustar repository update 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,9 @@ gem 'rails', '3.0.12'
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
-gem 'radiustar', '~> 0.0.6'
+#gem 'radiustar', '~> 0.0.6'
+#Temp radiustar repository for ipaddr version yanked
+gem 'radiustar', :git =>'git://github.com/idemarinis/radiustar.git'
 gem 'packet', '0.1.15', :git => 'git://github.com/dguerri/packet.git'
 gem 'backgroundrb-rails3', :require => 'backgroundrb'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,13 @@ GIT
   specs:
     packet (0.1.15)
 
+GIT
+  remote: git://github.com/idemarinis/radiustar.git
+  revision: 5da12697c863389cbdfa5b7895d62d00de2696f4
+  specs:
+    radiustar (0.0.7)
+      ipaddr_extensions (= 1.0.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -60,7 +67,7 @@ GEM
     highline (1.6.11)
     hirb (0.6.2)
     i18n (0.5.0)
-    ipaddr_extensions (2012.1.13)
+    ipaddr_extensions (1.0.0)
     jquery-rails (0.2.7)
       rails (~> 3.0)
       thor (~> 0.14.4)
@@ -87,8 +94,6 @@ GEM
       rack (>= 1.0.0)
     rack-test (0.5.7)
       rack (>= 1.0)
-    radiustar (0.0.6)
-      ipaddr_extensions (>= 2012.1.13)
     rails (3.0.12)
       actionmailer (= 3.0.12)
       actionpack (= 3.0.12)
@@ -139,7 +144,7 @@ DEPENDENCIES
   jquery-rails (~> 0.2.6)
   mysql
   packet (= 0.1.15)!
-  radiustar (~> 0.0.6)
+  radiustar!
   rails (= 3.0.12)
   rails3-generators (~> 0.17.4)
   ruby-debug


### PR DESCRIPTION
This is a temporary patch for radiustar repository caused by ipaddr failed dependecies
